### PR TITLE
pass file name to file

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ function adapter<StateT, CustomT, RequestContext>(
       let fileFields = {};
       if (files) {
         fileFields = Object.keys(files).reduce((memo: any, name) => {
-          memo[name] = new runtime.make.File(files[name].path, files[name].size);
+          memo[name] = new runtime.make.File(files[name].path, files[name].size, files[name].name);
           return memo;
         }, {});
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/smartlyio/oats.git"
   },
   "peerDependencies": {
-    "@smartlyio/oats-runtime": "2.10.0",
+    "@smartlyio/oats-runtime": "^2.10.0",
     "koa": "^2.3.0",
     "koa-body": "^4.0.4",
     "koa-router": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/smartlyio/oats.git"
   },
   "peerDependencies": {
-    "@smartlyio/oats-runtime": "^2.8.0",
+    "@smartlyio/oats-runtime": "2.10.0",
     "koa": "^2.3.0",
     "koa-body": "^4.0.4",
     "koa-router": "^10.0.0",
@@ -49,8 +49,8 @@
     "eslint-config-prettier": "6.15.0",
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jest": "23.20.0",
-    "nodemon": "2.0.7",
     "eslint-plugin-prettier": "3.3.1",
+    "nodemon": "2.0.7",
     "prettier": "2.2.1",
     "ts-node": "9.1.1",
     "typescript": "3.9.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-koa-adapter",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "MIT",
   "description": "Koa adapter for Oats",
   "private": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1401,12 +1401,12 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.15:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-lodash@^4.17.20:
+lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
Currently oats strips the file object from many fields including the name. Add name field to the file object.

~~Need to update the oat-runtime once [this](https://github.com/smartlyio/oats-runtime/pull/119) is merged & published~~