### PR TITLE
Allow zero length arrays as bodies

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,8 +24,18 @@ function adapter<StateT, CustomT, RequestContext>(
       }
       const contentType = ctx.request.type;
       const requestBody = (ctx.request as any).body;
-      const value = Array.isArray(requestBody) ? requestBody : { ...requestBody, ...fileFields };
-      const body = Object.keys(value).length > 0 ? { value, contentType } : undefined;
+      let body;
+
+      if (Array.isArray(requestBody)) {
+        body = { value: requestBody, contentType };
+      } else if (typeof requestBody === 'object') {
+        const bodyWithFileFields = { ...requestBody, ...fileFields };
+        body =
+          Object.keys(bodyWithFileFields).length > 0
+            ? { value: bodyWithFileFields, contentType }
+            : undefined;
+      }
+
       const result = await handler({
         path,
         method: runtime.server.assertMethod(ctx.method.toLowerCase()),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-koa-adapter",
-  "version": "2.3.0",
+  "version": "2.3.1-beta.1",
   "license": "MIT",
   "description": "Koa adapter for Oats",
   "private": false,


### PR DESCRIPTION
This change should allow zero length arrays as bodies without converting them to `undefined`